### PR TITLE
Refactor modal component

### DIFF
--- a/src/components/Memos/MemoForm/hooks.ts
+++ b/src/components/Memos/MemoForm/hooks.ts
@@ -51,7 +51,7 @@ export function useMemoForm() {
                 recognition.abort();
             }
 
-            if (currentMemo) {
+            if (currentMemo !== undefined) {
                 dispatchMemos({
                     type: 'SET_CURRENT_MEMO',
                     payload: undefined,
@@ -77,13 +77,13 @@ export function useMemoForm() {
             },
         });
 
-        dispatchModal({ isVisible: false, component: undefined, type: undefined });
+        dispatchModal({ isVisible: false, component: undefined, componentProps: undefined });
     }, [dispatchMemos, description]);
 
     const handleSaveMemo = useCallback(() => {
         if (currentMemo) {
             dispatchMemos({ type: 'UPDATE_MEMO', payload: { ...currentMemo, description } });
-            dispatchModal({ isVisible: false, component: undefined, type: undefined });
+            dispatchModal({ isVisible: false, component: undefined, componentProps: undefined });
         }
     }, [dispatchMemos, currentMemo, description]);
 

--- a/src/components/Memos/MemoForm/hooks.ts
+++ b/src/components/Memos/MemoForm/hooks.ts
@@ -77,13 +77,13 @@ export function useMemoForm() {
             },
         });
 
-        dispatchModal({ isVisible: false, component: undefined });
+        dispatchModal({ isVisible: false, component: undefined, type: undefined });
     }, [dispatchMemos, description]);
 
     const handleSaveMemo = useCallback(() => {
         if (currentMemo) {
             dispatchMemos({ type: 'UPDATE_MEMO', payload: { ...currentMemo, description } });
-            dispatchModal({ isVisible: false, component: undefined });
+            dispatchModal({ isVisible: false, component: undefined, type: undefined });
         }
     }, [dispatchMemos, currentMemo, description]);
 

--- a/src/components/Memos/MemoForm/index.tsx
+++ b/src/components/Memos/MemoForm/index.tsx
@@ -1,10 +1,8 @@
-import { memo } from 'react';
-
 import { useMemoForm } from './hooks';
 import { MemoFormProps } from './types';
 import './styles.css';
 
-export const MemoForm = memo((props: MemoFormProps) => {
+export const MemoForm = (props: MemoFormProps) => {
     const { type } = props;
 
     const {
@@ -58,4 +56,4 @@ export const MemoForm = memo((props: MemoFormProps) => {
             </div>
         </div>
     );
-});
+};

--- a/src/components/Memos/MemoForm/types.ts
+++ b/src/components/Memos/MemoForm/types.ts
@@ -1,3 +1,3 @@
 export interface MemoFormProps {
-    type: 'CREATE' | 'EDIT';
+    type: 'CREATE' | 'EDIT' | undefined;
 }

--- a/src/components/Memos/MemoForm/types.ts
+++ b/src/components/Memos/MemoForm/types.ts
@@ -1,3 +1,3 @@
 export interface MemoFormProps {
-    type: 'CREATE' | 'EDIT' | undefined;
+    type: 'CREATE' | 'EDIT';
 }

--- a/src/components/Memos/MemoList/hooks.ts
+++ b/src/components/Memos/MemoList/hooks.ts
@@ -23,7 +23,8 @@ export function useMemoList() {
 
         modalContext.dispatch({
             isVisible: true,
-            component: <MemoForm type="EDIT" />,
+            component: MemoForm,
+            type: 'EDIT',
         });
     };
 

--- a/src/components/Memos/MemoList/hooks.ts
+++ b/src/components/Memos/MemoList/hooks.ts
@@ -24,7 +24,7 @@ export function useMemoList() {
         modalContext.dispatch({
             isVisible: true,
             component: MemoForm,
-            type: 'EDIT',
+            componentProps: { type: 'EDIT' },
         });
     };
 

--- a/src/components/Memos/__tests__/MemoList.test.ts
+++ b/src/components/Memos/__tests__/MemoList.test.ts
@@ -27,7 +27,7 @@ describe('useMemoList', () => {
             state: {
                 isVisible: false,
                 component: undefined,
-                type: undefined,
+                componentProps: undefined,
             },
             dispatch: mockModalDispatch,
         });
@@ -75,7 +75,7 @@ describe('useMemoList', () => {
         expect(mockModalDispatch).toBeCalledWith({
             isVisible: true,
             component: MemoForm,
-            type: 'EDIT',
+            componentProps: { type: 'EDIT' },
         });
         expect(mockModalDispatch.mock.calls[0][0].component).toBe(MemoForm);
     });

--- a/src/components/Memos/__tests__/MemoList.test.ts
+++ b/src/components/Memos/__tests__/MemoList.test.ts
@@ -26,7 +26,8 @@ describe('useMemoList', () => {
         jest.spyOn(ModalContextModule, 'useModalContext').mockReturnValue({
             state: {
                 isVisible: false,
-                component: null,
+                component: undefined,
+                type: undefined,
             },
             dispatch: mockModalDispatch,
         });
@@ -73,9 +74,9 @@ describe('useMemoList', () => {
         });
         expect(mockModalDispatch).toBeCalledWith({
             isVisible: true,
-            component: expect.any(Object),
+            component: MemoForm,
+            type: 'EDIT',
         });
-        expect(mockModalDispatch.mock.calls[0][0].component.type).toBe(MemoForm);
-        expect(mockModalDispatch.mock.calls[0][0].component.props.type).toBe('EDIT');
+        expect(mockModalDispatch.mock.calls[0][0].component).toBe(MemoForm);
     });
 });

--- a/src/components/Memos/__tests__/Memos.test.ts
+++ b/src/components/Memos/__tests__/Memos.test.ts
@@ -11,7 +11,8 @@ describe('useMemos', () => {
         jest.spyOn(ModalContextModule, 'useModalContext').mockReturnValue({
             state: {
                 isVisible: false,
-                component: null,
+                component: undefined,
+                type: undefined,
             },
             dispatch: mockDispatch,
         });
@@ -25,9 +26,9 @@ describe('useMemos', () => {
 
         expect(mockDispatch).toBeCalledWith({
             isVisible: true,
-            component: expect.any(Object),
+            component: MemoForm,
+            type: 'CREATE',
         });
-        expect(mockDispatch.mock.calls[0][0].component.type).toBe(MemoForm);
-        expect(mockDispatch.mock.calls[0][0].component.props.type).toBe('CREATE');
+        expect(mockDispatch.mock.calls[0][0].component).toBe(MemoForm);
     });
 });

--- a/src/components/Memos/__tests__/Memos.test.ts
+++ b/src/components/Memos/__tests__/Memos.test.ts
@@ -12,7 +12,7 @@ describe('useMemos', () => {
             state: {
                 isVisible: false,
                 component: undefined,
-                type: undefined,
+                componentProps: undefined,
             },
             dispatch: mockDispatch,
         });
@@ -27,7 +27,7 @@ describe('useMemos', () => {
         expect(mockDispatch).toBeCalledWith({
             isVisible: true,
             component: MemoForm,
-            type: 'CREATE',
+            componentProps: { type: 'CREATE' },
         });
         expect(mockDispatch.mock.calls[0][0].component).toBe(MemoForm);
     });

--- a/src/components/Memos/hooks.ts
+++ b/src/components/Memos/hooks.ts
@@ -11,7 +11,7 @@ export function useMemos() {
         dispatch({
             isVisible: true,
             component: MemoForm,
-            type: 'CREATE',
+            componentProps: { type: 'CREATE' },
         });
     }, [dispatch]);
 

--- a/src/components/Memos/hooks.ts
+++ b/src/components/Memos/hooks.ts
@@ -10,7 +10,8 @@ export function useMemos() {
     const handleAddMemoModalOpen = useCallback(() => {
         dispatch({
             isVisible: true,
-            component: <MemoForm type="CREATE" />,
+            component: MemoForm,
+            type: 'CREATE',
         });
     }, [dispatch]);
 

--- a/src/components/Modal/context.tsx
+++ b/src/components/Modal/context.tsx
@@ -1,21 +1,23 @@
 import { createContext, useContext, useState } from 'react';
 
+import { MemoFormProps } from 'src/components/Memos/MemoForm/types';
+
 import { ModalContextProviderProps, ModalProps } from './types';
 
 interface ModalContextProps {
-    state: ModalProps | undefined;
-    dispatch: React.Dispatch<ModalProps>;
+    state: ModalProps<MemoFormProps> | undefined;
+    dispatch: React.Dispatch<ModalProps<MemoFormProps>>;
 }
 
 export const ModalContext = createContext<ModalContextProps>({
-    state: { isVisible: false, component: undefined, type: undefined },
+    state: { isVisible: false, component: undefined, componentProps: undefined },
     dispatch: () => null,
 });
 
 export function ModalContextProvider(props: ModalContextProviderProps) {
     const { children } = props;
 
-    const [modalState, setModalState] = useState<ModalProps | undefined>();
+    const [modalState, setModalState] = useState<ModalProps<MemoFormProps> | undefined>();
 
     return (
         <ModalContext.Provider value={{ state: modalState, dispatch: setModalState }}>

--- a/src/components/Modal/context.tsx
+++ b/src/components/Modal/context.tsx
@@ -8,7 +8,7 @@ interface ModalContextProps {
 }
 
 export const ModalContext = createContext<ModalContextProps>({
-    state: { isVisible: false, component: null },
+    state: { isVisible: false, component: undefined, type: undefined },
     dispatch: () => null,
 });
 

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -4,25 +4,34 @@ import './styles.css';
 export function Modal() {
     const { state, dispatch } = useModalContext();
 
-    if (state && state.component && state.isVisible) {
-        const { component, type } = state;
-
-        return (
-            <div className="modal-container">
-                <div className="modal-content">
-                    <div
-                        className="close-modal"
-                        onClick={() =>
-                            dispatch({ isVisible: false, component: undefined, type: undefined })
-                        }
-                    >
-                        x
-                    </div>
-                    {component({ type: type })}
-                </div>
-            </div>
-        );
+    if (!state || !state.isVisible) {
+        return null;
     }
 
-    return null;
+    const { component: Component, componentProps } = state;
+
+    if (!Component || componentProps === undefined) {
+        return null;
+    }
+
+    return (
+        <div className="modal-container">
+            <div className="modal-content">
+                <div
+                    className="close-modal"
+                    onClick={() =>
+                        dispatch({
+                            isVisible: false,
+                            component: undefined,
+                            componentProps: undefined,
+                        })
+                    }
+                >
+                    x
+                </div>
+
+                <Component {...componentProps} />
+            </div>
+        </div>
+    );
 }

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -4,19 +4,21 @@ import './styles.css';
 export function Modal() {
     const { state, dispatch } = useModalContext();
 
-    if (state && state.isVisible) {
-        const { component } = state;
+    if (state && state.component && state.isVisible) {
+        const { component, type } = state;
 
         return (
             <div className="modal-container">
                 <div className="modal-content">
                     <div
                         className="close-modal"
-                        onClick={() => dispatch({ isVisible: false, component: undefined })}
+                        onClick={() =>
+                            dispatch({ isVisible: false, component: undefined, type: undefined })
+                        }
                     >
                         x
                     </div>
-                    {component}
+                    {component({ type: type })}
                 </div>
             </div>
         );

--- a/src/components/Modal/types.ts
+++ b/src/components/Modal/types.ts
@@ -1,6 +1,9 @@
+import { MemoFormProps } from 'src/components/Memos/MemoForm/types';
+
 export interface ModalProps {
     isVisible: boolean;
-    component: React.ReactNode;
+    component: ((props: MemoFormProps) => JSX.Element) | undefined;
+    type: MemoFormProps['type'];
 }
 
 export interface ModalContextProviderProps {

--- a/src/components/Modal/types.ts
+++ b/src/components/Modal/types.ts
@@ -1,9 +1,7 @@
-import { MemoFormProps } from 'src/components/Memos/MemoForm/types';
-
-export interface ModalProps {
+export interface ModalProps<T> {
     isVisible: boolean;
-    component: ((props: MemoFormProps) => JSX.Element) | undefined;
-    type: MemoFormProps['type'];
+    component: ((props: T) => JSX.Element) | undefined;
+    componentProps: T | undefined;
 }
 
 export interface ModalContextProviderProps {


### PR DESCRIPTION
Pass type as prop to modal component with component as a function instead of ReactNode
Remove memo from MemoForm component